### PR TITLE
Fixes file buffer re-opening

### DIFF
--- a/lib/save-session.coffee
+++ b/lib/save-session.coffee
@@ -10,6 +10,7 @@ module.exports =
     restoreOpenFiles: true
     restoreOpenFileContents: true
     restoreCursor: true
+    skipSavePrompt: true
     bufferSaveFile: atom.config.configDirPath + '/save-session-buffer.json'
 
   activate: (state) ->
@@ -38,6 +39,9 @@ module.exports =
     if @getShouldRestoreProject() and project? and not atom.project.getPath()?
       @restoreProject(project)
 
+    if @getShouldSkipSavePrompt()
+      @disableSavePrompt()
+
     @addListeners()
 
   getBufferSaveFile: ->
@@ -65,6 +69,9 @@ module.exports =
     for tab in $('.tab-bar').children('li')
       if $(tab).hasClass('active')
         return $(tab).children('.title').data('path')
+
+  getShouldSkipSavePrompt: ->
+    atom.config.get 'save-session.skipSavePrompt'
 
   saveDimensions: ->
     window = atom.getWindowDimensions()
@@ -138,3 +145,10 @@ module.exports =
       editor.onDidStopChanging =>
         @saveProject()
         @saveBuffers()
+
+  disableSavePrompt: ->
+    #Hack to override the promptToSaveItem method of Pane
+    #There doesn't appear to be a direct way to get to the Pane object
+    #with require(), unfortunately, so I have to result to this hack.
+    atom.workspace.getActivePane().constructor.prototype.promptToSaveItem = (item) ->
+      return true;


### PR DESCRIPTION
I couldn't get my files to re-open when I opened Atom and tracked it down to an 'is not' statement where 'isnt' was what was needed. 

I also fixed issue #2 by adding an option to disable the save on exit message.  The method I used to do this is hacky, but it works for now.
