### PR TITLE
Add dataSaveFolder to config to appease schema enforcement

### DIFF
--- a/lib/save-session.coffee
+++ b/lib/save-session.coffee
@@ -78,6 +78,9 @@ module.exports =
       type: 'integer'
       default: 200
       description: 'The width of the file tree to be restored'
+    dataSaveFolder:
+      type: 'string'
+      description: 'The folder in which to save project states'
 
 
   activate: (state) ->


### PR DESCRIPTION
As of Atom 0.166, `dataSaveFolder` is being removed from save-session's config.
Per @maxbrunsfeld in mpeterson2/save-session#43, Atom now requires that
dataSaveFolder be added explicitly to the config schema.

Fixes mpeterson2/save-session#43, mpeterson2/save-session#45, and
mpeterson2/save-session#46.