### PR TITLE
Fix for the damn annoying lets mash all projects in a single one bug

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -83,8 +83,8 @@ module.exports =
       @saveFolderDefault()
       folder = @saveFolder()
 
-    if @restoreOpenFilesPerProject() and atom.project.rootDirectories[0].path?
-      path = @transformProjectPath(atom.project.rootDirectories[0].path)
+    if @restoreOpenFilesPerProject() and (atom.project.path || atom.project.rootDirectories[0].path)?
+      path = @transformProjectPath(atom.project.path || atom.project.rootDirectories[0].path)
       return folder + @pathSeparator() + path + @pathSeparator() + 'project.json'
     else
       return folder + @pathSeparator() + 'undefined' + @pathSeparator() + 'project.json'

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -83,8 +83,8 @@ module.exports =
       @saveFolderDefault()
       folder = @saveFolder()
 
-    if @restoreOpenFilesPerProject() and atom.project.path?
-      path = @transformProjectPath(atom.project.path)
+    if @restoreOpenFilesPerProject() and atom.project.rootDirectories[0].path?
+      path = @transformProjectPath(atom.project.rootDirectories[0].path)
       return folder + @pathSeparator() + path + @pathSeparator() + 'project.json'
     else
       return folder + @pathSeparator() + 'undefined' + @pathSeparator() + 'project.json'

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -24,7 +24,7 @@ describe 'saveFile tests', ->
     it 'With a project', ->
       spyOn(Config, 'restoreOpenFilesPerProject').andReturn(true)
       spyOn(Config, 'transformProjectPath').andReturn('project')
-      atom.project.path = 'project'
+      atom.project.path || atom.project.rootDirectories[0].path = 'project'
 
       expect(Config.saveFile()).toBe('folder/project/project.json')
       expect(Config.saveFolder).toHaveBeenCalled()
@@ -36,22 +36,22 @@ describe 'saveFile tests', ->
     it 'With no project', ->
       spyOn(Config, 'restoreOpenFilesPerProject').andReturn(true)
       spyOn(Config, 'transformProjectPath')
-      atom.project.path = undefined
+      atom.project.path || atom.project.rootDirectories[0].path = undefined
 
     it 'Without restoring per project without project', ->
       spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
       spyOn(Config, 'transformProjectPath')
-      atom.project.path = undefined
+      atom.project.path || atom.project.rootDirectories[0].path = undefined
 
     it 'Without restoring per project with project', ->
       spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
       spyOn(Config, 'transformProjectPath')
-      atom.project.path = 'path'
+      atom.project.path || atom.project.rootDirectories[0].path = 'path'
 
     it 'Without project or restoring per project', ->
       spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
       spyOn(Config, 'transformProjectPath')
-      atom.project.path = undefined
+      atom.project.path || atom.project.rootDirectories[0].path = undefined
 
     afterEach ->
       expect(Config.saveFile()).toBe('folder/undefined/project.json')


### PR DESCRIPTION
Fix for the damn annoying lets mash all projects in a single one bug where all your open files from various projects get mashed into one, stopping you from opening some projects sometimes as it keeps opening another directory tree.