### PR TITLE
A series of hacks to enable reliable restoring of sessions in new versions of Atom

### DIFF
--- a/lib/files.coffee
+++ b/lib/files.coffee
@@ -10,7 +10,7 @@ module.exports =
       if exists
         Fs.readFile Config.saveFile(), encoding: 'utf8', (err, str) =>
           buffers = JSON.parse(str)
-          if Config.restoreOpenFiles()
+          if Config.restoreOpenFiles() and localStorage.sessions_restore == "yes"
             @restore buffers
 
     @addListeners()

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -4,35 +4,40 @@ Config = require './config'
 module.exports =
 
   activate: ->
-    @resetProject = true
-    project = Config.project()
-    if Config.restoreProject() and project? and not atom.project.getPath()?
-      @restore(project)
-
+    previousRestoreState = localStorage.sessions_restore
+    localStorage.sessions_restore = "no" # Disable files restore for now
+    setTimeout ->
+      project = Config.project()
+      if Config.restoreProject() and project? and atom.project.getPaths().length == 0
+        if previousRestoreState == "yes"
+          localStorage.sessions_restore = "yes"
+          module.exports.restore(project)
+          setTimeout -> # Give time to the files module before changing state
+            localStorage.sessions_restore = "no"
+          , 700
+    , 300
     @addListeners()
 
+  deactivate: ->
+    localStorage.sessions_restore = "yes"
+
   save: ->
-    Config.project atom.project.getPath()
+    Config.project atom.project.getPaths()[0]
 
   restore: (path) ->
     if path isnt '0'
-      atom.project.setPath path
-
-  onNewWindow: ->
-    if @resetProject
-      Config.project(undefined, true)
-      @resetProject = true
+      atom.project.setPaths [path]
 
   onReopenProject: ->
-    @resetProject = false
+    localStorage.sessions_restore = "yes"
     atom.workspaceView.trigger 'application:new-window'
 
   addListeners: ->
     $(window).on 'focus', (event) =>
       @save()
 
-    atom.emitter.preempt 'application:new-window', =>
-      @onNewWindow()
+    $(window).on 'unload', (event) =>
+      @deactivate()
 
     atom.commands.add 'atom-workspace', 'save-session:reopen-project', =>
       @onReopenProject()


### PR DESCRIPTION
Opening a directory reliably
And the new window behavior
To be honest it is pretty awful, but works for me