### PR TITLE
Multiple Root folders, déprécations, reduced HDD trafic by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@ If you haven't downloaded the package yet, this is what you can customize.
  - `Data Save Folder` - The root folder to save the session data in.
  - `Restore Cursor` - Whether or not the cursor position should be restored.
  - `Restore File Tree Size` - Whether or not the file tree size will be restored.
- - `Restore Open Files Per Project` - If enabled, only files from previous sessions
- with the save project will be restored. Otherwise, files from your last session
- will be restored.
  - `Restore Open File Contents` - Whether or not file contents will be
  automatically restored on load. This has no effect if `Restore Open Files` is
  disabled.
  - `Restore Open Files` - Whether or not files will be reopened.
- - `Restore Project` - Whether or not the project will be reopened.
+ - `Restore Projects` - Whether or not projects will be reopened.
  - `Restore Window` - Whether or not the window size/positions will be saved.
  - `Skip Save Prompt` - This will disable the save on exit prompt.
  - `Extra Delay` - Adds an extra delay for saving files when typing.

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -9,14 +9,15 @@ module.exports =
   disableNewBufferOnOpenAlways: (val, force) ->
     @config 'disableNewFileOnOpenAlways', val, force
 
-  restoreOpenFilesPerProject: (val, force) ->
-    @config 'restoreOpenFilesPerProject', val, force
-
   saveFolder: (val, force) ->
-    @config 'dataSaveFolder', val, force
+    saveFolderPath = @config 'dataSaveFolder', val, force
+    if not saveFolderPath?
+      @saveFolderDefault()
+      saveFolderPath = @saveFolder()
+    return saveFolderPath
 
-  restoreProject: (val, force) ->
-    @config 'restoreProject', val, force
+  restoreProjects: (val, force) ->
+    @config 'restoreProjects', val, force
 
   restoreWindow: (val, force) ->
     @config 'restoreWindow', val, force
@@ -43,8 +44,8 @@ module.exports =
     @config 'extraDelay', val, force
 
   # Saving specific configs
-  project: (val, force) ->
-    @config 'project', val, force
+  projects: (val, force) ->
+    @config 'projects', val, force
 
   windowX: (val, force) ->
     @config 'windowX', val, force
@@ -76,18 +77,18 @@ module.exports =
   isWindows: ->
     return Os.platform() is 'win32'
 
+  isArray: (value) ->
+    value and
+      typeof value is 'object' and
+        value instanceof Array and
+        typeof value.length is 'number' and
+        typeof value.splice is 'function' and
+        not (value.propertyIsEnumerable 'length')
+
   saveFile: ->
-    folder = @saveFolder()
+    saveFolderPath = @saveFolder()
 
-    if not folder?
-      @saveFolderDefault()
-      folder = @saveFolder()
-
-    if @restoreOpenFilesPerProject() and atom.project.rootDirectories[0]?.path?
-      path = @transformProjectPath(atom.project.rootDirectories[0].path)
-      return folder + @pathSeparator() + path + @pathSeparator() + 'project.json'
-    else
-      return folder + @pathSeparator() + 'undefined' + @pathSeparator() + 'project.json'
+    return saveFolderPath + @pathSeparator() + 'project.json'
 
   transformProjectPath: (path) ->
     if @isWindows

--- a/lib/dimensions.coffee
+++ b/lib/dimensions.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom'
+{$} = require 'atom-space-pen-views'
 Config = require './config'
 
 module.exports =
@@ -20,7 +20,6 @@ module.exports =
     @addListeners()
 
   save: ->
-    localStorage.sessionRestore = false
     window = atom.getWindowDimensions()
     treeSize = $('.tree-view-resizer').width()
     fullScreen = atom.isFullScreen()

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -1,30 +1,39 @@
-{$} = require 'atom'
+{$} = require 'atom-space-pen-views'
 Config = require './config'
 
 module.exports =
 
   activate: ->
     @resetProject = true
-    project = Config.project()
+    projects = Config.projects()
 
-    if Config.restoreProject() and project? and
-      atom.project.getPaths().length == 0 and
-      localStorage.sessionRestore == 'true'
+    ###console.log(Config.restoreProjects() and projects?)
+    console.log(atom.project.getPaths())
+    console.log(localStorage.sessionRestore)
+    console.log(Config.restoreProjects() and projects? and localStorage.sessionRestore)###
+
+    if (Config.restoreProjects() and projects? and localStorage.sessionRestore)
         localStorage.sessionRestore = false
-        @restore(project)
+        @restore(projects)
 
     @addListeners()
 
   save: ->
-    Config.project atom.project.getPath()
+    Config.projects atom.project.getPaths()
 
-  restore: (path) ->
-    if path isnt '0'
-      atom.project.setPath path
+    ###console.log('config saved with :')
+    console.log(atom.project.getPaths())###
+    console.log('config saved is now :')
+    console.log(Config.projects())
+
+  restore: (paths) ->
+    if Config.isArray(paths)
+      for path in paths
+        atom.project.addPath(path)
 
   onReopenProject: ->
     localStorage.sessionRestore = true
-    atom.workspaceView.trigger 'application:new-window'
+    atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:new-window')
 
   addListeners: ->
     $(window).on 'focus', (event) =>

--- a/lib/save-session.coffee
+++ b/lib/save-session.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom'
+{$} = require 'atom-space-pen-views'
 Fs = require 'fs'
 Config = require './config'
 Dimensions = require './dimensions'
@@ -14,10 +14,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Auto close the default file opened by Atom'
-    restoreProject:
+    restoreProjects:
       type: 'boolean'
       default: true
-      description: 'Restore the last opened project'
+      description: 'Restore last opened projects'
     restoreWindow:
       type: 'boolean'
       default: true
@@ -34,10 +34,6 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Restore the contents of files that were unsaved in the last session'
-    restoreOpenFilesPerProject:
-      type: 'boolean'
-      default: true
-      description: 'Restore files from previous sessions per project'
     restoreCursor:
       type: 'boolean'
       default: true
@@ -52,12 +48,14 @@ module.exports =
       description: 'Disable the save on exit prompt'
     extraDelay:
       type: 'integer'
-      default: 0
-      description: "Add an extra delay time in ms for saving files after typing"
-    project:
-      type: 'string'
+      default: 500
+      description: "Add an extra delay time in ms for auto saving files after typing. Be carefull, auto saving copy the file to the HDD, a low value can slow down your computer."
+    projects:
+      type: 'array'
       default: '0'
-      description: 'The last open project that will be restored'
+      description: 'Lasts opened projects that will be restored'
+      items:
+        type: 'string'
     windowX:
       type: 'integer'
       default: -1
@@ -81,7 +79,6 @@ module.exports =
     dataSaveFolder:
       type: 'string'
       description: 'The folder in which to save project states'
-
 
   activate: (state) ->
     # Default settings that couldn't be set up top.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,81 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "mkdirp": ">=0.5.0"
+    "mkdirp": ">=0.5.0",
+    "atom-space-pen-views": "^2.0.3"
   },
   "devDependencies": {
     "q": "^1.0.1"
+  },
+  "readme": "# Save Session (Atom Package) [![Build Status](https://travis-ci.org/mpeterson2/save-session.svg?branch=master)](https://travis-ci.org/mpeterson2/save-session)\n\n## Project Status\n\nI haven't been working on Save Session lately because I have stopped using Atom, and I am finishing up school and have less time for side projects than when I started it. I'll still look at pull requests and give my thoughts on issues, but I probably won't be writing much more code for this project. Luckily, it looks like the Atom developers have decided to include this into Atom core and this package will eventually be deprecated. Here is the [issue](https://github.com/atom/atom/issues/1603) for more info.\n\n## What is Save Session\n\nSave Session is designed to reopen your last session in [Atom](https://atom.io/).\nIt automatically saves all file's contents and other session information in the\nbackground so you don't have to worry as much about losing an important file.\nI liked how [Sublime Text](http://www.sublimetext.com/) does this, so I wanted\nto recreate it for Atom\n\n![preview](https://raw.githubusercontent.com/mpeterson2/save-session/master/preview.gif)\n\n## What is saved\n\n - The project currently being worked on\n - The files currently being worked on, whether they are saved to disk or not\n - The size of the window and file tree\n - The position of the cursor\n\n## Settings\n\nIf you haven't downloaded the package yet, this is what you can customize.\n\n### User settings\n\n - `Disable New File On Open` - Whether or not to auto close the new file auto\n opened by Atom.\n - `Data Save Folder` - The root folder to save the session data in.\n - `Restore Cursor` - Whether or not the cursor position should be restored.\n - `Restore File Tree Size` - Whether or not the file tree size will be restored.\n - `Restore Open Files Per Project` - If enabled, only files from previous sessions\n with the save project will be restored. Otherwise, files from your last session\n will be restored.\n - `Restore Open File Contents` - Whether or not file contents will be\n automatically restored on load. This has no effect if `Restore Open Files` is\n disabled.\n - `Restore Open Files` - Whether or not files will be reopened.\n - `Restore Project` - Whether or not the project will be reopened.\n - `Restore Window` - Whether or not the window size/positions will be saved.\n - `Skip Save Prompt` - This will disable the save on exit prompt.\n - `Extra Delay` - Adds an extra delay for saving files when typing.\n - `Restore Scroll Position` - **Experimental** Saves the scroll position of files.\n\n### Other settings\nThese settings are used by the package to restore data. You can change them, but\nthey will all be set by the package when a related event happens.\n\n - `Height` - The height of the editor\n - `Width` - The width of the editor\n - `X` - The x position of the editor\n - `Y` - The y position of the editor\n\n### Commands\n\nThere is currently only one command: `Save Session: Reopen Project`. This is\nmostly for me, or other developers. All it does is reopen the current project.\nThis allows you to edit a package and reload it without exiting out of your\ncurrent window or loosing the project in the new window.\n\n## How it works\n\nSave Session saves your data in two different ways. The first, is through Atom's\nsettings API. Simple things like window dimensions are saved here, but nothing\ncomplicated. The second is on your file system. Things like files info is stored\nin a folder at `<atom package dir>/save-session/<project path>/projects.json` by\ndefault.\n\n## Contributing\n\nFeel free to submit issues if you see anything misbehaving. The more information\nyou can give me about your issue the better. Things like operating system, Atom\nversion, Save Session version, your Save Session config, other installed\npackages, and any error messages in the console that mention Save Session are\nhelpful.\n\nPull requests are also welcome if you want to improve or change something.\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/mpeterson2/save-session/issues"
+  },
+  "homepage": "https://github.com/mpeterson2/save-session",
+  "_id": "save-session@0.12.5",
+  "_shasum": "fc8ad9759be5c3de05df1b13c0a68640bc90762b",
+  "_resolved": "file:..\\d-11533-7824-r9mvo\\package.tgz",
+  "_from": "..\\d-11533-7824-r9mvo\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [
+      {
+        "name": "mkdirp",
+        "version": "0.5.0",
+        "path": "node_modules\\mkdirp\\index.js"
+      },
+      {
+        "name": "minimist",
+        "version": "0.0.8",
+        "path": "node_modules\\mkdirp\\node_modules\\minimist\\index.js"
+      }
+    ],
+    "extensions": {
+      ".coffee": [
+        "lib\\config.coffee",
+        "lib\\dimensions.coffee",
+        "lib\\files.coffee",
+        "lib\\first-buffer.coffee",
+        "lib\\project.coffee",
+        "lib\\save-prompt.coffee",
+        "lib\\save-session.coffee"
+      ],
+      ".js": [
+        "node_modules\\mkdirp\\bin\\cmd.js",
+        "node_modules\\mkdirp\\examples\\pow.js",
+        "node_modules\\mkdirp\\index.js",
+        "node_modules\\mkdirp\\node_modules\\minimist\\example\\parse.js",
+        "node_modules\\mkdirp\\node_modules\\minimist\\index.js"
+      ],
+      ".json": [
+        "node_modules\\mkdirp\\node_modules\\minimist\\package.json",
+        "node_modules\\mkdirp\\package.json",
+        "package.json"
+      ]
+    },
+    "folders": [
+      {
+        "paths": [
+          "lib",
+          "",
+          "spec"
+        ],
+        "dependencies": {
+          "mkdirp": ">=0.5.0"
+        }
+      },
+      {
+        "paths": [
+          "node_modules\\mkdirp\\bin",
+          "node_modules\\mkdirp\\examples",
+          "node_modules\\mkdirp",
+          "node_modules\\mkdirp\\test"
+        ],
+        "dependencies": {
+          "minimist": "0.0.8"
+        }
+      }
+    ]
   }
 }

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -20,59 +20,27 @@ describe 'saveFile tests', ->
     spyOn(Config, 'saveFolder').andReturn('folder')
     spyOn(Config, 'pathSeparator').andReturn('/')
 
-  describe 'real projects', ->
-    it 'With a project', ->
-      spyOn(Config, 'restoreOpenFilesPerProject').andReturn(true)
-      spyOn(Config, 'transformProjectPath').andReturn('project')
-      atom.project.path || atom.project.rootDirectories[0].path = 'project'
+  describe 'projects restoring', ->
+    it 'is a project to be restored', ->
+      atom.project.path || atom.project.rootDirectories[0].path = '/'
 
-      expect(Config.saveFile()).toBe('folder/project/project.json')
+      expect(Config.saveFile()).toBe('folder/project.json')
       expect(Config.saveFolder).toHaveBeenCalled()
-      expect(Config.restoreOpenFilesPerProject).toHaveBeenCalled()
-      expect(Config.transformProjectPath).toHaveBeenCalled()
-      expect(Config.pathSeparator).toHaveBeenCalled()
-
-  describe 'undefined projects', ->
-    it 'With no project', ->
-      spyOn(Config, 'restoreOpenFilesPerProject').andReturn(true)
-      spyOn(Config, 'transformProjectPath')
-      atom.project.path || atom.project.rootDirectories[0].path = undefined
-
-    it 'Without restoring per project without project', ->
-      spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
-      spyOn(Config, 'transformProjectPath')
-      atom.project.path || atom.project.rootDirectories[0].path = undefined
-
-    it 'Without restoring per project with project', ->
-      spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
-      spyOn(Config, 'transformProjectPath')
-      atom.project.path || atom.project.rootDirectories[0].path = 'path'
-
-    it 'Without project or restoring per project', ->
-      spyOn(Config, 'restoreOpenFilesPerProject').andReturn(false)
-      spyOn(Config, 'transformProjectPath')
-      atom.project.path || atom.project.rootDirectories[0].path = undefined
-
-    afterEach ->
-      expect(Config.saveFile()).toBe('folder/undefined/project.json')
-      expect(Config.saveFolder).toHaveBeenCalled()
-      expect(Config.restoreOpenFilesPerProject).toHaveBeenCalled()
-      expect(Config.transformProjectPath).not.toHaveBeenCalled()
       expect(Config.pathSeparator).toHaveBeenCalled()
 
 
 describe 'transformProjectPath tests', ->
-  it 'Windows with :', ->
+  it 'is Windows with :', ->
     spyOn(Config, 'isWindows').andReturn(true)
     path = Config.transformProjectPath('c:\\path')
     expect(path).toBe('c\\path')
 
-  it 'Windows without :', ->
+  it 'is Windows without :', ->
     spyOn(Config, 'isWindows').andReturn(true)
     path = Config.transformProjectPath('path\\more')
     expect(path).toBe('path\\more')
 
-  it 'Not windows', ->
+  it 'is not windows', ->
     spyOn(Config, 'isWindows').andReturn(false)
     path = Config.transformProjectPath('path/more')
     expect(path).toBe('path/more')

--- a/spec/dimensions-spec.coffee
+++ b/spec/dimensions-spec.coffee
@@ -1,5 +1,5 @@
 Dimensions = require '../lib/dimensions'
-{$} = require 'atom'
+{$} = require 'atom-space-pen-views'
 Config = require '../lib/config'
 
 describe 'activate tests', ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -1,78 +1,83 @@
-{$} = require 'atom'
+{$} = require 'atom-space-pen-views'
 Config = require '../lib/config'
 Project = require '../lib/project'
-{WorkspaceView} = require 'atom'
 
 describe 'activate tests', ->
   beforeEach ->
     spyOn(Project, 'restore')
     spyOn(Project, 'addListeners')
 
-  it 'Config.restoreProject is true, project exists, no project is open', ->
-    spyOn(Config, 'project').andReturn('project')
-    spyOn(Config, 'restoreProject').andReturn(true)
-    spyOn(atom.project, 'getPaths').andReturn([])
+  it 'failed to restore project with : Config.restoreProjects as true, project list exists, no project is open', ->
+    spyOn(Config, 'projects').andReturn(['/project'])
+    spyOn(Config, 'restoreProjects').andReturn(true)
 
     Project.activate()
 
-    expect(Config.project).toHaveBeenCalled()
-    expect(Config.restoreProject).toHaveBeenCalled()
-    expect(atom.project.getPaths).toHaveBeenCalled()
+    expect(Config.projects).toHaveBeenCalled()
+    expect(Config.restoreProjects).toHaveBeenCalled()
     # can't get this test to work correctly, but it does work.
     #expect(Project.restore).toHaveBeenCalledWith('project')
     expect(Project.addListeners).toHaveBeenCalled()
 
-  it 'Config.restoreProject is true, project exists, project is open', ->
-    spyOn(Config, 'project').andReturn('project')
-    spyOn(Config, 'restoreProject').andReturn(true)
-    spyOn(atom.project, 'getPaths').andReturn([])
-
-    Project.activate()
-
-    expect(Config.project).toHaveBeenCalled()
-    expect(Config.restoreProject).toHaveBeenCalled()
-    expect(atom.project.getPaths).toHaveBeenCalled()
-    expect(Project.restore).not.toHaveBeenCalled()
-    expect(Project.addListeners).toHaveBeenCalled()
-
-  it 'Config.restoreProject is true, no project exists', ->
-    spyOn(Config, 'project').andReturn('project')
-    spyOn(Config, 'restoreProject').andReturn(false)
+  it 'tryed to restore with : Config.restoreProjects is true, empty project list', ->
+    spyOn(Config, 'projects').andReturn([])
+    spyOn(Config, 'restoreProjects').andReturn(false)
     spyOn(atom.project, 'getPaths')
 
     Project.activate()
 
-    expect(Config.project).toHaveBeenCalled()
-    expect(Config.restoreProject).toHaveBeenCalled()
+    expect(Config.projects).toHaveBeenCalled()
+    expect(Config.restoreProjects).toHaveBeenCalled()
     expect(atom.project.getPaths).not.toHaveBeenCalled()
     expect(Project.restore).not.toHaveBeenCalled()
     expect(Project.addListeners).toHaveBeenCalled()
 
-  it 'Config.restoreProject is false', ->
-    spyOn(Config, 'project').andReturn('project')
-    spyOn(Config, 'restoreProject').andReturn(false)
+  it 'tryed to restore with : Config.restoreProjects is true, undefined project list', ->
+    spyOn(Config, 'projects').andReturn(undefined)
+    spyOn(Config, 'restoreProjects').andReturn(false)
     spyOn(atom.project, 'getPaths')
 
     Project.activate()
 
-    expect(Config.project).toHaveBeenCalled()
-    expect(Config.restoreProject).toHaveBeenCalled()
+    expect(Config.projects).toHaveBeenCalled()
+    expect(Config.restoreProjects).toHaveBeenCalled()
+    expect(atom.project.getPaths).not.toHaveBeenCalled()
+    expect(Project.restore).not.toHaveBeenCalled()
+    expect(Project.addListeners).toHaveBeenCalled()
+
+  it 'tryed to restore with : Config.restoreProjects is false', ->
+    spyOn(Config, 'projects').andReturn(['/project'])
+    spyOn(Config, 'restoreProjects').andReturn(false)
+    spyOn(atom.project, 'getPaths')
+
+    Project.activate()
+
+    expect(Config.projects).toHaveBeenCalled()
+    expect(Config.restoreProjects).toHaveBeenCalled()
     expect(atom.project.getPaths).not.toHaveBeenCalled()
     expect(Project.restore).not.toHaveBeenCalled()
     expect(Project.addListeners).toHaveBeenCalled()
 
 
 describe 'restore tests', ->
-  it 'contains a valid path', ->
-    path = Math.random() + 1
-    spyOn(atom.project, 'setPath')
+  it 'contains valid paths', ->
+    paths = ['/this/is/a/valid/path', 'this/as/well']
+    spyOn(atom.project, 'addPath')
 
-    Project.restore path
-    expect(atom.project.setPath).toHaveBeenCalledWith(path)
+    Project.restore paths
+    expect(atom.project.addPath).toHaveBeenCalledWith(paths[0])
+    expect(atom.project.addPath).toHaveBeenCalledWith(paths[1])
 
-  it 'contains an invalid path', ->
-    path = '0'
-    spyOn(atom.project, 'setPath')
+  it 'is not an array', ->
+    paths = {name:"john", age: 22}
+    spyOn(atom.project, 'addPath')
 
-    Project.restore path
-    expect(atom.project.setPath).not.toHaveBeenCalled()
+    Project.restore paths
+    expect(atom.project.addPath).not.toHaveBeenCalled()
+
+  it 'contains no paths', ->
+    paths = []
+    spyOn(atom.project, 'addPath')
+
+    Project.restore paths
+    expect(atom.project.addPath).not.toHaveBeenCalled()


### PR DESCRIPTION
Removed obsolete setting "reopen file per project" since atom now handdle
multiples projects in a window

Fixed #86 Fixed a bug where the session won't be restored after restarting
atom since localStorage.sessionRestore was set to 'false'when the file
were saved (it happened on editor.onDidDestroy, so the sesionRestore
variable will be set to false at next start).

Fixed #91 Projetcs opened by default at start are back.
Some changed were applyed :
  - While working on a restored session, if another one is oppened it
    won't restore a second time, open a new sesion instead.
  - When atom is closed and opening and use contextual menu "Open with
	Atom" on a folder it will add folder root but also restore old
	session (act as sublime text)
  - When atom is closed and opening and use contextual menu "Open with
    Atom" on a file it will add file panel but also restore old session (act as sublime text)

Fixed #92, #95, #97 Fixed all deprecations

Updated specs

Changed "extraDelay" default value to 500 ms (0 create a huge trafic on HDD when working with a lot of big files)

Changed save behavior : Editor won't be saved on editor::didDestroyed, atom use to close the editor on exit, so each editor would try to save each other, but the last one will override everithing and we sometime loose some editor at restart.