### PR TITLE
Fixed critical bug that will prevent atom to start

### DIFF
--- a/lib/files.coffee
+++ b/lib/files.coffee
@@ -7,7 +7,7 @@ module.exports =
 
   activate: (buffers) ->
     saveFilePath = Config.saveFile()
-    alert saveFilePath
+    
     Fs.exists saveFilePath, (exists) =>
       if exists
         Fs.readFile saveFilePath, encoding: 'utf8', (err, str) =>

--- a/lib/save-session.coffee
+++ b/lib/save-session.coffee
@@ -56,7 +56,7 @@ module.exports =
       description: "Add an extra delay time in ms for auto saving files after typing."
     projects:
       type: 'array'
-      default: '0'
+      default: []
       description: 'An array of the projects that will be restored'
       items:
         type: 'string'
@@ -82,6 +82,7 @@ module.exports =
       description: 'The width of the file tree to be restored'
     dataSaveFolder:
       type: 'string'
+      default: ''
       description: 'The folder in which to save project states'
 
   activate: (state) ->


### PR DESCRIPTION
An 'alert' (JS popup method) was left in files.coffee.
Atom won't start (probably cause the alert was showed up in atom before the windows was displayed to the user, so there is no way to close the alert).

Anyway with this alert, atom won't show up.