### PR TITLE
Deprecate for Atom >= 0.193.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Save Session (Atom Package) [![Build Status](https://travis-ci.org/mpeterson2/save-session.svg?branch=master)](https://travis-ci.org/mpeterson2/save-session)
 
-## Project Status
+## Project Status: Deprecated
 
-I haven't been working on Save Session lately because I have stopped using Atom, and I am finishing up school and have less time for side projects than when I started it. I'll still look at pull requests and give my thoughts on issues, but I probably won't be writing much more code for this project. Luckily, it looks like the Atom developers have decided to include this into Atom core and this package will eventually be deprecated. Here is the [issue](https://github.com/atom/atom/issues/1603) for more info.
+Save Session is deprecated as of Atom 0.193.0 - the same functionality [has been added to Atom core](https://github.com/atom/atom/issues/1603#issuecomment-93599126), and will continue to be refined until Atom 1.0.
 
 ## What is Save Session
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">0.50.0 <0.193.0"
   },
   "dependencies": {
     "mkdirp": ">=0.5.0",


### PR DESCRIPTION
https://github.com/atom/atom/issues/1603 has finally been implemented and will be released with Atom 0.193.0, so to avoid conflicts with this newly added core functionality, this PR deprecates Save Session for Atom 0.193.0 and beyond.

:beers: