### PR TITLE
Restore: overwrite buf if cached contents unchanged

### DIFF
--- a/lib/files.coffee
+++ b/lib/files.coffee
@@ -57,7 +57,7 @@ module.exports =
 
     # Replace the text if needed
     if Config.restoreOpenFileContents() and buffer.text? and buf? and
-      buf.getText() isnt buffer.text and Config.hashMyStr(buf.getText()) is buffer.diskText
+      buf.getText() isnt buffer.text and Config.hashMyStr(buf.cachedDiskContents) is buffer.diskText
         buf.setText(buffer.text)
 
   addListeners: ->


### PR DESCRIPTION
When the disk image of a buffer differs from the cachedDiskContents in
atom, we skip replacing the contents with our own version because,
presumably, the changed disk image is the one the user wants.  But it's
possible some other buffer-recovery function has resulted in a cache
difference (perhaps in core atom) and we are fooled because we look at
the cache when saving but at the disk when restoring.

Look at the cache when restoring so it matches what we saw when saving
since the check is only interested in ensuring we do not discard changes
from some outside process.

Fixes #129
